### PR TITLE
Fix fs-extra-promise install error and slight improvements

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -1,7 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
 NVM_NODEJS_ORG_MIRROR=https://jxcore.azureedge.net
 export NVM_NODEJS_ORG_MIRROR
 JX_NPM_JXB=jxb311
 export JX_NPM_JXB
+
+../Thali_CordovaPlugin/thali/install/setUpDesktop.sh
 
 mkdir -p thaliDontCheckIn/localdev
 cordova platform add android


### PR DESCRIPTION
See thaliproject/Thali_CordovaPlugin#1336. Also slight improvements for `prepare.sh`.
